### PR TITLE
Configure Dask dashboard link for binder

### DIFF
--- a/.dask/config.yaml
+++ b/.dask/config.yaml
@@ -1,0 +1,3 @@
+distributed:
+  dashboard:
+    link: "{JUPYTERHUB_BASE_URL}user/{JUPYTERHUB_USER}/proxy/{port}/status"

--- a/binder/start
+++ b/binder/start
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Replace DASK_DASHBOARD_URL with the proxy location
-sed -i -e "s|DASK_DASHBOARD_URL|{JUPYTERHUB_BASE_URL}user/{JUPYTERHUB_USER}/proxy/{port}/status|g" binder/jupyterlab-workspace.json
+sed -i -e "s|DASK_DASHBOARD_URL|${JUPYTERHUB_BASE_URL}user/${JUPYTERHUB_USER}/proxy/{port}/status|g" binder/jupyterlab-workspace.json
 
 # Import the workspace
 jupyter lab workspaces import binder/jupyterlab-workspace.json

--- a/binder/start
+++ b/binder/start
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Replace DASK_DASHBOARD_URL with the proxy location
-sed -i -e "s|DASK_DASHBOARD_URL|${JUPYTERHUB_BASE_URL}user/${JUPYTERHUB_USER}/proxy/{port}/status|g" binder/jupyterlab-workspace.json
+sed -i -e "s|DASK_DASHBOARD_URL|${JUPYTERHUB_BASE_URL}user/${JUPYTERHUB_USER}/proxy/8787/status|g" binder/jupyterlab-workspace.json
 
 # Import the workspace
 jupyter lab workspaces import binder/jupyterlab-workspace.json

--- a/binder/start
+++ b/binder/start
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Replace DASK_DASHBOARD_URL with the proxy location
-sed -i -e "s|DASK_DASHBOARD_URL|/user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
+sed -i -e "s|DASK_DASHBOARD_URL|{JUPYTERHUB_BASE_URL}user/{JUPYTERHUB_USER}/proxy/{port}/status|g" binder/jupyterlab-workspace.json
 
 # Import the workspace
 jupyter lab workspaces import binder/jupyterlab-workspace.json


### PR DESCRIPTION
This should ensure the dashboard link is built correctly by setting the dashboard URL for arbitrary JupyterHub URLs.

Test:
- [x] https://notebooks.gesis.org/binder/v2/gh/willirath/dask-sql-binder/patch-1?urlpath=lab
- [x] https://gke.mybinder.org/v2/gh/willirath/dask-sql-binder/patch-1?urlpath=lab
